### PR TITLE
Move jump functionality to separate class

### DIFF
--- a/lib/dinosaur.js
+++ b/lib/dinosaur.js
@@ -1,4 +1,5 @@
 var Collision = require('./collision');
+var Jump = require('./jump');
 
 function Dinosaur(canvas, bubOrBob) {
   this.height = 25;
@@ -109,78 +110,21 @@ Dinosaur.prototype.move = function(floors) {
     this.rebornTime--;
   }
   if (this.status === "jumping") {
-    this.jump(floors);
+    new Jump().jump(floors, this);
   }
-  if (!onAFloor(floors, this)) {
+  if (!new Jump().onAFloor(floors, this)) {
     this.y += 2;
   }
   return this;
-};
-
-Dinosaur.prototype.jump = function(floors) {
-  var dino = this;
-  if ( stillJumpingUp(dino) ){
-    dontHitCeiling(dino);
-  } else if (jumpingDown(dino)) {
-    findNearestFloor(floors, dino);
-  } else if (finishedJumpingAndFalling(dino)) {
-    resetDino(dino);
-  }
-  return dino;
 };
 
 Dinosaur.prototype.setJumpingStatus = function() {
   if (!this.status) { this.status = "jumping"; }
 };
 
-function onThisFloor(floor, dino) {
-  var dino_collider = { x: dino.x + dino.width / 2, y: dino.y + dino.height };
-  var floor_receiver = { minX: floor.x,
-                         maxX: floor.x+floor.width,
-                         minY: floor.y,
-                         maxY: floor.y+floor.height };
-  if(Collision.collision(dino_collider, floor_receiver)) {
-    return true;
-  }
-}
-
-function stillJumpingUp(dino) {
-  return dino.count < dino.jumpSteps;
-}
-
-function jumpingDown(dino) {
-  return dino.count >= dino.jumpSteps && dino.count < 2 * dino.jumpSteps;
-}
-
-function finishedJumpingAndFalling(dino) {
-  return dino.count === 2 * dino.jumpSteps;
-}
-
 function resetDino(dino) {
   dino.status = null;
   dino.count = 0;
-}
-
-function findNearestFloor(floors, dino){
-  dino.count++;
-  floors.forEach(function(floor){
-    if (onThisFloor(floor, dino)) {
-      dino.y = floor.y-floor.height/2-dino.height-2;
-      resetDino(dino);
-    }
-  });
-  dino.y += dino.jumpSize;
-  return dino;
-}
-
-function dontHitCeiling(dino) {
-  dino.count++;
-  if (dino.y - dino.jumpSize > 0){
-    dino.y -= dino.jumpSize;
-  } else {
-    dino.y = 0;
-    dino.count = dino.jumpSteps;
-  }
 }
 
 function createImage(imageSrc) {
@@ -188,17 +132,6 @@ function createImage(imageSrc) {
   image.src = imageSrc;
   image.style.visibility = 'hidden';
   return image;
-}
-
-function onAFloor(floors, dino) {
-  var floor;
-  for(var i = 0; i< floors.length; i++) {
-    floor = floors[i];
-    if (onThisFloor(floor, dino)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 function findVerticalFloors(floors){
@@ -225,7 +158,5 @@ function runIntoVerticalFloor(dino, verticalFloors, direction){
 function notOnTopWall(dino){
   return !(dino.y > 30 && dino.y < 34);
 }
-
-
 
 module.exports = Dinosaur;

--- a/lib/dinosaur.js
+++ b/lib/dinosaur.js
@@ -33,6 +33,7 @@ function Dinosaur(canvas, bubOrBob) {
   this.jumpSize = this.jumpTotal/this.jumpSteps;
   this.level = 1;
   this.floorHeight = 10;
+  this.jump = new Jump();
 }
 
 Dinosaur.prototype.reborn = function() {
@@ -110,9 +111,9 @@ Dinosaur.prototype.move = function(floors) {
     this.rebornTime--;
   }
   if (this.status === "jumping") {
-    new Jump().jump(floors, this);
+    this.jump.jump(floors, this);
   }
-  if (!new Jump().onAFloor(floors, this)) {
+  if (!this.jump.onAFloor(floors, this)) {
     this.y += 2;
   }
   return this;

--- a/lib/jump.js
+++ b/lib/jump.js
@@ -1,0 +1,77 @@
+var Collision = require('./collision');
+
+function Jump() {}
+
+Jump.prototype.jump = function(floors, element) {
+  if ( stillJumpingUp(element) ){
+    dontHitCeiling(element);
+  } else if (jumpingDown(element)) {
+    findNearestFloor(floors, element);
+  } else if (finishedJumpingAndFalling(element)) {
+    resetElement(element);
+  }
+  return this;
+};
+
+Jump.prototype.onThisFloor = function(floor, element) {
+  var element_collider = { x: element.x + element.width / 2, y: element.y + element.height };
+  var floor_receiver = { minX: floor.x,
+                         maxX: floor.x+floor.width,
+                         minY: floor.y,
+                         maxY: floor.y+floor.height };
+  if(Collision.collision(element_collider, floor_receiver)) {
+    return true;
+  }
+};
+
+Jump.prototype.onAFloor = function(floors, windup) {
+  var floor;
+  for(var i = 0; i< floors.length; i++) {
+    floor = floors[i];
+    if (new Jump().onThisFloor(floor, windup)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+function stillJumpingUp(element) {
+  return element.count < element.jumpSteps;
+}
+
+function dontHitCeiling(element) {
+  element.count++;
+  if (element.y - element.jumpSize > 0){
+    element.y -= element.jumpSize;
+  } else {
+    element.y = 0;
+    element.count = element.jumpSteps;
+  }
+}
+
+function jumpingDown(element) {
+  return element.count >= element.jumpSteps && element.count < 2 * element.jumpSteps;
+}
+
+function findNearestFloor(floors, element){
+  element.count++;
+  floors.forEach(function(floor){
+    if (new Jump().onThisFloor(floor, element)) {
+      element.y = floor.y-floor.height/2-element.height-2;
+      resetElement(element);
+    }
+  });
+  element.y += element.jumpSize;
+  return element;
+}
+
+function finishedJumpingAndFalling(element) {
+  return element.count === 2 * element.jumpSteps;
+}
+
+function resetElement(element) {
+  element.status = null;
+  element.count = 0;
+}
+
+module.exports = Jump;

--- a/lib/levels.js
+++ b/lib/levels.js
@@ -18,8 +18,8 @@ Levels.prototype.twoPlayer = function(canvas) {
           new Floor(canvas, 0, 142, 20, 455),
           new Floor(canvas, 95, 218, 20, 455),
           new Floor(canvas, 50, 294, 20, 200),
-          new Floor(canvas, 300, 294, 20, 200)]
-}
+          new Floor(canvas, 300, 294, 20, 200)];
+};
 
 function levelOne(canvas) {
   return [new Floor(canvas, 85, 100, 10, 230),

--- a/lib/windup.js
+++ b/lib/windup.js
@@ -1,4 +1,4 @@
-var Collision = require('./collision');
+var Jump = require('./jump');
 
 function Windup(canvas, dino, twoPlayer){
   this.x = Math.random() * (canvas.width - 17);
@@ -34,19 +34,17 @@ Windup.prototype.img = function(){
   }
 };
 
-
 Windup.prototype.fall = function() {
   this.y += this.fallRate;
   return this;
 };
 
 Windup.prototype.move = function(floors) {
-
   if (this.status === "falling" && (this.y < this.canvas.height - this.height - this.floorHeight)) {
     this.fall();
   } else if (this.status === "jumping") {
-    this.jump(floors);
-  } else if (this.x >= this.dino.x) {
+    new Jump().jump(floors, this);
+ } else if (this.x >= this.dino.x) {
     this.direction = "left";
     this.x -= this.paceRate;
   } else if (this.x < this.dino.x) {
@@ -54,7 +52,7 @@ Windup.prototype.move = function(floors) {
     this.x += this.paceRate;
   }
 
-  if (this.status !== "falling" && !onAFloor(floors, this)) {
+  if (this.status !== "falling" && !new Jump().onAFloor(floors, this)) {
     this.y += 2;
   }
 
@@ -65,21 +63,8 @@ Windup.prototype.move = function(floors) {
   if (this.status !== "falling" && this.status !== "jumping" && Math.random() < 0.02 && this.twoPlayer) {
     this.status = "jumping";
   }
-
   return this;
 };
-
-Windup.prototype.jump = function(floors) {
-  if ( stillJumpingUp(this) ){
-    dontHitCeiling(this);
-  } else if (jumpingDown(this)) {
-    findNearestFloor(floors, this);
-  } else if (finishedJumpingAndFalling(this)) {
-    resetWindup(this);
-  }
-  return this;
-};
-
 
 function createImage(imageSrc) {
   var image = document.createElement("img");
@@ -88,65 +73,4 @@ function createImage(imageSrc) {
   return image;
 }
 
-function stillJumpingUp(windup) {
-  return windup.count < windup.jumpSteps;
-}
-
-function dontHitCeiling(windup) {
-  windup.count++;
-  if (windup.y - windup.jumpSize > 0){
-    windup.y -= windup.jumpSize;
-  } else {
-    windup.y = 0;
-    windup.count = windup.jumpSteps;
-  }
-}
-
-function jumpingDown(windup) {
-  return windup.count >= windup.jumpSteps && windup.count < 2 * windup.jumpSteps;
-}
-
-function findNearestFloor(floors, windup){
-  windup.count++;
-  floors.forEach(function(floor){
-    if (onThisFloor(floor, windup)) {
-      windup.y = floor.y-windup.height;
-      resetWindup(windup);
-    }
-  });
-  windup.y += windup.jumpSize;
-  return windup;
-}
-
-function onThisFloor(floor, windup) {
-  var windup_collider = { x: windup.x + windup.width / 2, y: windup.y + windup.height };
-  var floor_receiver = { minX: floor.x,
-                         maxX: floor.x+floor.width,
-                         minY: floor.y,
-                         maxY: floor.y+floor.height };
-  if(Collision.collision(windup_collider, floor_receiver)) {
-    return true;
-  }
-}
-
-function finishedJumpingAndFalling(windup) {
-  return windup.count === 2 * windup.jumpSteps;
-}
-
-function resetWindup(windup) {
-  windup.status = null;
-  windup.count = 0;
-}
-
-
-function onAFloor(floors, windup) {
-  var floor;
-  for(var i = 0; i< floors.length; i++) {
-    floor = floors[i];
-    if (onThisFloor(floor, windup)) {
-      return true;
-    }
-  }
-  return false;
-}
 module.exports = Windup;

--- a/lib/windup.js
+++ b/lib/windup.js
@@ -18,6 +18,7 @@ function Windup(canvas, dino, twoPlayer){
   this.jumpSize = this.jumpTotal/this.jumpSteps;
   this.status = "falling";
   this.dino = dino;
+  this.jump = new Jump();
   if (twoPlayer) { this.twoPlayer = true; }
 }
 
@@ -43,7 +44,7 @@ Windup.prototype.move = function(floors) {
   if (this.status === "falling" && (this.y < this.canvas.height - this.height - this.floorHeight)) {
     this.fall();
   } else if (this.status === "jumping") {
-    new Jump().jump(floors, this);
+    this.jump.jump(floors, this);
  } else if (this.x >= this.dino.x) {
     this.direction = "left";
     this.x -= this.paceRate;
@@ -52,7 +53,7 @@ Windup.prototype.move = function(floors) {
     this.x += this.paceRate;
   }
 
-  if (this.status !== "falling" && !new Jump().onAFloor(floors, this)) {
+  if (this.status !== "falling" && !this.jump.onAFloor(floors, this)) {
     this.y += 2;
   }
 

--- a/static/main.bundle.js
+++ b/static/main.bundle.js
@@ -59,10 +59,10 @@
 	'use strict';
 
 	var Dinosaur = __webpack_require__(2);
-	var Windup = __webpack_require__(4);
-	var GamePlay = __webpack_require__(5);
-	var Levels = __webpack_require__(8);
-	var ScoreKeeper = __webpack_require__(10);
+	var Windup = __webpack_require__(5);
+	var GamePlay = __webpack_require__(6);
+	var Levels = __webpack_require__(9);
+	var ScoreKeeper = __webpack_require__(11);
 
 	function Game(canvas) {
 	  this.canvas = canvas;
@@ -289,9 +289,10 @@
 /* 2 */
 /***/ function(module, exports, __webpack_require__) {
 
-	"use strict";
+	'use strict';
 
 	var Collision = __webpack_require__(3);
+	var Jump = __webpack_require__(4);
 
 	function Dinosaur(canvas, bubOrBob) {
 	  this.height = 25;
@@ -402,24 +403,12 @@
 	    this.rebornTime--;
 	  }
 	  if (this.status === "jumping") {
-	    this.jump(floors);
+	    new Jump().jump(floors, this);
 	  }
-	  if (!onAFloor(floors, this)) {
+	  if (!new Jump().onAFloor(floors, this)) {
 	    this.y += 2;
 	  }
 	  return this;
-	};
-
-	Dinosaur.prototype.jump = function (floors) {
-	  var dino = this;
-	  if (stillJumpingUp(dino)) {
-	    dontHitCeiling(dino);
-	  } else if (jumpingDown(dino)) {
-	    findNearestFloor(floors, dino);
-	  } else if (finishedJumpingAndFalling(dino)) {
-	    resetDino(dino);
-	  }
-	  return dino;
 	};
 
 	Dinosaur.prototype.setJumpingStatus = function () {
@@ -428,54 +417,9 @@
 	  }
 	};
 
-	function onThisFloor(floor, dino) {
-	  var dino_collider = { x: dino.x + dino.width / 2, y: dino.y + dino.height };
-	  var floor_receiver = { minX: floor.x,
-	    maxX: floor.x + floor.width,
-	    minY: floor.y,
-	    maxY: floor.y + floor.height };
-	  if (Collision.collision(dino_collider, floor_receiver)) {
-	    return true;
-	  }
-	}
-
-	function stillJumpingUp(dino) {
-	  return dino.count < dino.jumpSteps;
-	}
-
-	function jumpingDown(dino) {
-	  return dino.count >= dino.jumpSteps && dino.count < 2 * dino.jumpSteps;
-	}
-
-	function finishedJumpingAndFalling(dino) {
-	  return dino.count === 2 * dino.jumpSteps;
-	}
-
 	function resetDino(dino) {
 	  dino.status = null;
 	  dino.count = 0;
-	}
-
-	function findNearestFloor(floors, dino) {
-	  dino.count++;
-	  floors.forEach(function (floor) {
-	    if (onThisFloor(floor, dino)) {
-	      dino.y = floor.y - floor.height / 2 - dino.height - 2;
-	      resetDino(dino);
-	    }
-	  });
-	  dino.y += dino.jumpSize;
-	  return dino;
-	}
-
-	function dontHitCeiling(dino) {
-	  dino.count++;
-	  if (dino.y - dino.jumpSize > 0) {
-	    dino.y -= dino.jumpSize;
-	  } else {
-	    dino.y = 0;
-	    dino.count = dino.jumpSteps;
-	  }
 	}
 
 	function createImage(imageSrc) {
@@ -483,17 +427,6 @@
 	  image.src = imageSrc;
 	  image.style.visibility = 'hidden';
 	  return image;
-	}
-
-	function onAFloor(floors, dino) {
-	  var floor;
-	  for (var i = 0; i < floors.length; i++) {
-	    floor = floors[i];
-	    if (onThisFloor(floor, dino)) {
-	      return true;
-	    }
-	  }
-	  return false;
 	}
 
 	function findVerticalFloors(floors) {
@@ -585,6 +518,90 @@
 
 	var Collision = __webpack_require__(3);
 
+	function Jump() {}
+
+	Jump.prototype.jump = function (floors, element) {
+	  if (stillJumpingUp(element)) {
+	    dontHitCeiling(element);
+	  } else if (jumpingDown(element)) {
+	    findNearestFloor(floors, element);
+	  } else if (finishedJumpingAndFalling(element)) {
+	    resetElement(element);
+	  }
+	  return this;
+	};
+
+	Jump.prototype.onThisFloor = function (floor, element) {
+	  var element_collider = { x: element.x + element.width / 2, y: element.y + element.height };
+	  var floor_receiver = { minX: floor.x,
+	    maxX: floor.x + floor.width,
+	    minY: floor.y,
+	    maxY: floor.y + floor.height };
+	  if (Collision.collision(element_collider, floor_receiver)) {
+	    return true;
+	  }
+	};
+
+	Jump.prototype.onAFloor = function (floors, windup) {
+	  var floor;
+	  for (var i = 0; i < floors.length; i++) {
+	    floor = floors[i];
+	    if (new Jump().onThisFloor(floor, windup)) {
+	      return true;
+	    }
+	  }
+	  return false;
+	};
+
+	function stillJumpingUp(element) {
+	  return element.count < element.jumpSteps;
+	}
+
+	function dontHitCeiling(element) {
+	  element.count++;
+	  if (element.y - element.jumpSize > 0) {
+	    element.y -= element.jumpSize;
+	  } else {
+	    element.y = 0;
+	    element.count = element.jumpSteps;
+	  }
+	}
+
+	function jumpingDown(element) {
+	  return element.count >= element.jumpSteps && element.count < 2 * element.jumpSteps;
+	}
+
+	function findNearestFloor(floors, element) {
+	  element.count++;
+	  floors.forEach(function (floor) {
+	    if (new Jump().onThisFloor(floor, element)) {
+	      element.y = floor.y - floor.height / 2 - element.height - 2;
+	      resetElement(element);
+	    }
+	  });
+	  element.y += element.jumpSize;
+	  return element;
+	}
+
+	function finishedJumpingAndFalling(element) {
+	  return element.count === 2 * element.jumpSteps;
+	}
+
+	function resetElement(element) {
+	  element.status = null;
+	  element.count = 0;
+	}
+
+	module.exports = Jump;
+
+/***/ },
+/* 5 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	var Jump = __webpack_require__(4);
+
 	function Windup(canvas, dino, twoPlayer) {
 	  this.x = Math.random() * (canvas.width - 17);
 	  this.y = 0;
@@ -627,11 +644,10 @@
 	};
 
 	Windup.prototype.move = function (floors) {
-
 	  if (this.status === "falling" && this.y < this.canvas.height - this.height - this.floorHeight) {
 	    this.fall();
 	  } else if (this.status === "jumping") {
-	    this.jump(floors);
+	    new Jump().jump(floors, this);
 	  } else if (this.x >= this.dino.x) {
 	    this.direction = "left";
 	    this.x -= this.paceRate;
@@ -640,7 +656,7 @@
 	    this.x += this.paceRate;
 	  }
 
-	  if (this.status !== "falling" && !onAFloor(floors, this)) {
+	  if (this.status !== "falling" && !new Jump().onAFloor(floors, this)) {
 	    this.y += 2;
 	  }
 
@@ -650,18 +666,6 @@
 
 	  if (this.status !== "falling" && this.status !== "jumping" && Math.random() < 0.02 && this.twoPlayer) {
 	    this.status = "jumping";
-	  }
-
-	  return this;
-	};
-
-	Windup.prototype.jump = function (floors) {
-	  if (stillJumpingUp(this)) {
-	    dontHitCeiling(this);
-	  } else if (jumpingDown(this)) {
-	    findNearestFloor(floors, this);
-	  } else if (finishedJumpingAndFalling(this)) {
-	    resetWindup(this);
 	  }
 	  return this;
 	};
@@ -673,70 +677,10 @@
 	  return image;
 	}
 
-	function stillJumpingUp(windup) {
-	  return windup.count < windup.jumpSteps;
-	}
-
-	function dontHitCeiling(windup) {
-	  windup.count++;
-	  if (windup.y - windup.jumpSize > 0) {
-	    windup.y -= windup.jumpSize;
-	  } else {
-	    windup.y = 0;
-	    windup.count = windup.jumpSteps;
-	  }
-	}
-
-	function jumpingDown(windup) {
-	  return windup.count >= windup.jumpSteps && windup.count < 2 * windup.jumpSteps;
-	}
-
-	function findNearestFloor(floors, windup) {
-	  windup.count++;
-	  floors.forEach(function (floor) {
-	    if (onThisFloor(floor, windup)) {
-	      windup.y = floor.y - windup.height;
-	      resetWindup(windup);
-	    }
-	  });
-	  windup.y += windup.jumpSize;
-	  return windup;
-	}
-
-	function onThisFloor(floor, windup) {
-	  var windup_collider = { x: windup.x + windup.width / 2, y: windup.y + windup.height };
-	  var floor_receiver = { minX: floor.x,
-	    maxX: floor.x + floor.width,
-	    minY: floor.y,
-	    maxY: floor.y + floor.height };
-	  if (Collision.collision(windup_collider, floor_receiver)) {
-	    return true;
-	  }
-	}
-
-	function finishedJumpingAndFalling(windup) {
-	  return windup.count === 2 * windup.jumpSteps;
-	}
-
-	function resetWindup(windup) {
-	  windup.status = null;
-	  windup.count = 0;
-	}
-
-	function onAFloor(floors, windup) {
-	  var floor;
-	  for (var i = 0; i < floors.length; i++) {
-	    floor = floors[i];
-	    if (onThisFloor(floor, windup)) {
-	      return true;
-	    }
-	  }
-	  return false;
-	}
 	module.exports = Windup;
 
 /***/ },
-/* 5 */
+/* 6 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -765,9 +709,9 @@
 	exports.endGameSequence2P = endGameSequence2P;
 	exports.decrementFruitValues = decrementFruitValues;
 	var Collision = __webpack_require__(3);
-	var Fruit = __webpack_require__(6);
-	var Windup = __webpack_require__(4);
-	var Bubble = __webpack_require__(7);
+	var Fruit = __webpack_require__(7);
+	var Windup = __webpack_require__(5);
+	var Bubble = __webpack_require__(8);
 
 	function gameOver(dino, bubbles, windups, fruits) {
 	  if (dino.lives === 0 || dino.level === 3 && allFilledBubblesPopped(bubbles) && windups.length === 0 && allFruitsCollected(fruits)) {
@@ -1039,7 +983,7 @@
 	}
 
 /***/ },
-/* 6 */
+/* 7 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -1090,7 +1034,7 @@
 	module.exports = Fruit;
 
 /***/ },
-/* 7 */
+/* 8 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -1209,12 +1153,12 @@
 	module.exports = Bubble;
 
 /***/ },
-/* 8 */
+/* 9 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
 
-	var Floor = __webpack_require__(9);
+	var Floor = __webpack_require__(10);
 
 	function Levels() {}
 
@@ -1258,7 +1202,7 @@
 	module.exports = Levels;
 
 /***/ },
-/* 9 */
+/* 10 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -1280,7 +1224,7 @@
 	module.exports = Floor;
 
 /***/ },
-/* 10 */
+/* 11 */
 /***/ function(module, exports) {
 
 	"use strict";

--- a/test/dinosaur-test.js
+++ b/test/dinosaur-test.js
@@ -105,21 +105,6 @@ describe('dinosaur', function(){
     });
   });
 
-  it('jumps', function(){
-    this.dino.jump([]);
-    assert.equal(this.dino.y, 65-this.dino.jumpSize);
-    assert.equal(this.dino.count, 1);
-    this.dino.count = 21;
-    this.dino.jump([]);
-    assert.equal(this.dino.y, 65);
-    assert.equal(this.dino.count, 22);
-    this.dino.count = 40;
-    this.dino.jump([]);
-    assert.equal(this.dino.y, 65);
-    assert.equal(this.dino.count, 0);
-    assert.equal(this.dino.status, null);
-  });
-
   it('can be reborn', function(){
     this.dino.reborn();
     assert.equal(this.dino.x, 100);

--- a/test/index.js
+++ b/test/index.js
@@ -6,3 +6,4 @@ require('../test/fruits-test');
 require('../test/floors-test');
 require('../test/levels-test');
 require('../test/game-play-test');
+require('../test/jump-test');

--- a/test/jump-test.js
+++ b/test/jump-test.js
@@ -1,0 +1,29 @@
+var assert = require('chai').assert;
+var Jump = require('../lib/jump');
+var Dinosaur = require('../lib/dinosaur');
+var Floor = require('../lib/floors');
+
+describe('jump', function(){
+  beforeEach(function() {
+    this.canvas = { width: 200, height: 100};
+    this.dino = new Dinosaur(this.canvas);
+    this.jump = new Jump();
+    this.floors = [new Floor(this.canvas, 0, this.canvas.height-10, 10, this.canvas.width)];
+  });
+
+  it('jumps', function(){
+    this.jump.jump(this.floors, this.dino);
+    assert.equal(this.dino.y, 65-this.dino.jumpSize);
+    assert.equal(this.dino.count, 1);
+    this.dino.count = 21;
+    this.jump.jump(this.floors, this.dino);
+    assert.equal(this.dino.y, 65);
+    assert.equal(this.dino.count, 22);
+    this.dino.count = 40;
+    this.jump.jump(this.floors, this.dino);
+    assert.equal(this.dino.y, 65);
+    assert.equal(this.dino.count, 0);
+    assert.equal(this.dino.status, null);
+  });
+
+});

--- a/test/windup-test.js
+++ b/test/windup-test.js
@@ -1,12 +1,14 @@
 var assert = require('chai').assert;
 var Windup = require('../lib/windup');
 var Dinosaur = require('../lib/dinosaur');
+var Floor = require('../lib/floors');
 
 describe('windup', function(){
   beforeEach(function(){
      this.canvas = { width: 200, height: 100};
-     this.windup = new Windup(this.canvas);
      this.dino = new Dinosaur(this.canvas);
+     this.windup = new Windup(this.canvas, this.dino);
+     this.floors = [new Floor(this.canvas, 0, this.canvas.height-10, 10, this.canvas.width)];
   });
 
   it('has initial properties', function(){
@@ -32,7 +34,7 @@ describe('windup', function(){
     this.windup.y = this.canvas.height;
     this.dino.x = 100;
     this.windup.x = 50;
-    this.windup.move(this.dino);
+    this.windup.move(this.floors);
     assert.equal(this.windup.x, 50.75);
     this.dino.x = 0;
     this.windup.x = 50;


### PR DESCRIPTION
Both dinosaur and windup reference this jump and use internal functions
Remove jump tests from dinosaur, add to jump class
Add dinosaur to windup test to allow that test to pass

What's this PR do?
Moves duplicated Jump code that was in both windup and dinosaur to its own class that is used in both

Where should the reviewer start?
With Jump file - that is the code that was duplicated in both and removed

How should this be manually tested?
Probably play the game - two player version to make sure both dinos and windups are jumping properly

Any background context you want to provide?

Screenshots (if appropriate)
Functionality is the same

What gif best describes this PR or how it makes you feel?
Not my thing :)

@rrgayhart @ksk5280 @erinnachen 

closes #98 