### PR TITLE
Refactor end of game functions

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -45,10 +45,7 @@ function gameLoop(){
   GamePlay.drawScore(game.dino, game.context);
   GamePlay.decrementFruitValues(game.fruits);
   if (GamePlay.gameOver(game.dino, game.bubbles, game.windups, game.fruits)) {
-    ScoreKeeper.recordScore(game);
-    ScoreKeeper.loadHighScores();
-    GamePlay.endGameSequence(game.dino);
-    return true;
+    return endGameActions1P(game);
   }
   var newWindups = GamePlay.levelUp(game.dino, game.fruits, game.windups, game.canvas, game.bubbles);
   if (newWindups) {
@@ -56,6 +53,13 @@ function gameLoop(){
     GamePlay.nextLevel(game);
   }
   requestAnimationFrame(gameLoop.bind(game));
+}
+
+function endGameActions1P(game) {
+  ScoreKeeper.recordScore(game);
+  ScoreKeeper.loadHighScores();
+  GamePlay.endGameSequence(game.dino);
+  return true;
 }
 
 function gameLoop2P(){
@@ -80,17 +84,20 @@ function gameLoop2P(){
   GamePlay.drawScore2(game.dino2, game.context);
   GamePlay.decrementFruitValues(game.fruits);
   if (GamePlay.gameOver2P(game.dino, game.dino2)) {
-    if (game.dino.points > game.dino2.points){
-      ScoreKeeper.recordScore2P(game, game.dino);
-    } else {
-      ScoreKeeper.recordScore2P(game, game.dino2);
-    }
-    ScoreKeeper.loadHighScores2P();
-    clearInterval(game.intID);
-    GamePlay.endGameSequence2P(game.dino, game.dino2);
-    return true;
+    return endGameActions2P(game);
   }
   requestAnimationFrame(gameLoop2P.bind(game));
+}
+
+function endGameActions2P(game) {
+  if (game.dino.points > game.dino2.points){
+    ScoreKeeper.recordScore2P(game, game.dino);
+  } else {
+    ScoreKeeper.recordScore2P(game, game.dino2);
+  }
+  ScoreKeeper.loadHighScores2P();
+  clearInterval(game.intID);
+  GamePlay.endGameSequence2P(game.dino, game.dino2);
 }
 
 function setKeyBindings(game){

--- a/lib/levels.js
+++ b/lib/levels.js
@@ -18,8 +18,8 @@ Levels.prototype.twoPlayer = function(canvas) {
           new Floor(canvas, 0, 142, 20, 455),
           new Floor(canvas, 95, 218, 20, 455),
           new Floor(canvas, 50, 294, 20, 200),
-          new Floor(canvas, 300, 294, 20, 200)]
-}
+          new Floor(canvas, 300, 294, 20, 200)];
+};
 
 function levelOne(canvas) {
   return [new Floor(canvas, 85, 100, 10, 230),


### PR DESCRIPTION
Previously, the game file included end-of-game functions that were embedded within the if statement another function. I extracted the function calls within the if statements to their own functions (endGameActions1P and endGameActions2P), to help with code readability.

I also added a couple semi-colons in `levels.js` for style.

The test suite passes after these changes.

Please check the high-score logging for 1P games, as there all high score lines are filled after one game (worked like this prior to and after my branch refactoring). @adriennedomingus @erinnachen @rrgayhart
<img width="1074" alt="screen shot 2016-05-31 at 11 31 16 am" src="https://cloud.githubusercontent.com/assets/13153182/15684202/45153714-2723-11e6-804f-b461d2eb542e.png">

This PR will blow your mind.
![mind-blown](https://media.giphy.com/media/EldfH1VJdbrwY/giphy.gif)